### PR TITLE
Make sync match async

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var gzip = require('zlib').gzip;
-var gzipSync = require('zlib-browserify').gzipSync;
+var gzipSync = require('browserify-zlib').gzipSync;
 
 module.exports = function (str, cb) {
 	if (!str) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "concat-stream": "^1.4.1",
-    "zlib-browserify": "^0.0.3"
+    "browserify-zlib": "^0.1.4"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test.js
+++ b/test.js
@@ -18,4 +18,12 @@ describe('gzipSize.sync()', function () {
 	it('should get the gzipped size', function () {
 		assert(gzipSize.sync(a) < a.length);
 	});
+	
+	it('should match async version', function(cb) {
+		gzipSize(a, function (err, size) {
+			assert(!err);
+			assert.equal(gzipSize.sync(a), size);
+			cb();
+		});
+	});
 });


### PR DESCRIPTION
A couple weeks ago I wrote a [replacement zlib module](https://github.com/devongovett/browserify-zlib) for browserify ([now merged](https://github.com/substack/node-browserify/pull/721)) with full node parity.  The previous one, being used here, [produces different output](https://github.com/brianloveswords/zlib-browserify#test-methodology-aka-why-doesnt-the-output-match-nodes-zlib) than Node's builtin zlib module.  I figured it would be worth making the sync and async functions in this module match.  Also, should be faster! :smile: 
