### PR TITLE
update engines requirement in package.json to be greater or equal to node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "bin": "cli.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
[This commit](https://github.com/sindresorhus/gzip-size/commit/541b6d3134d58caa8025c77071e5d5ff1b9aed5a) dropped Node 0.10.0 compatibility so let's update the engines prop in package.json to reflect this.

Possible it could be ">=0.11.0"? But testing is done on iojs and node 0.12 so that seemed like the safer bet.

thanks!