### PR TITLE
Add `fileSync()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,3 +54,8 @@ module.exports.file = (path, options) => {
 		gzipStream.on('gzip-size', resolve);
 	});
 };
+
+module.exports.fileSync = (path, options) => {
+	const data = fs.readFileSync(path);
+	return module.exports.sync(data, options);
+};

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ Returns a `Promise` for the size of the file.
 
 Type: `string`
 
+### gzipSize.fileSync(path, [options])
+
+Returns the size of the file.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -54,6 +54,10 @@ test('file - get the gzipped size', async t => {
 	t.true(await m.file('test.js') < fixture.length);
 });
 
+test('fileSync - get the gzipped size', t => {
+	t.is(m.fileSync('test.js'), m.sync(fixture));
+});
+
 test('file - match async version', async t => {
 	t.is(await m.file('test.js'), await m(fixture));
 });


### PR DESCRIPTION
Idea was to keep parity with
`gzipSize` and `gzipSize.sync`.