### PR TITLE
Add missing TypeScript type for `gzipSize.fileSync`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,13 @@ declare const gzipSize: {
 	@returns The size of the file.
 	*/
 	file(path: string, options?: gzipSize.Options): Promise<number>;
+
+	/**
+	Get the gzipped size of a file.
+
+	@returns The size of the file.
+	*/
+	fileSync(path: string, options?: gzipSize.Options): number;
 };
 
 export = gzipSize;

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare const gzipSize: {
 	file(path: string, options?: gzipSize.Options): Promise<number>;
 
 	/**
-	Get the gzipped size of a file.
+	Synchronously get the gzipped size of a file.
 
 	@returns The size of the file.
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,3 +14,5 @@ const gstream = fs
 expectType<number | undefined>(gstream.gzipSize);
 expectType<Promise<number>>(gzipSize.file('index.d.ts'));
 expectType<Promise<number>>(gzipSize.file('index.d.ts', {chunkSize: 1}));
+expectType<number>(gzipSize.fileSync('index.d.ts'));
+expectType<number>(gzipSize.fileSync('index.d.ts', {chunkSize: 1}));


### PR DESCRIPTION
Add missing type definition for gzipSync.fileSync